### PR TITLE
feat: Than 프레임워크 구현

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -37,7 +37,8 @@ class BaseProjectFactory: ProjectFactory {
         .external(name: "Lottie"),
         .external(name: "SnapKit"),
         .target(name: "Queenfisher"),
-        .target(name: "FirestoreService")
+        .target(name: "FirestoreService"),
+        .target(name: "Than")
     ]
     
     let testDependencies: [TargetDependency] = [
@@ -126,6 +127,15 @@ class BaseProjectFactory: ProjectFactory {
                 infoPlist: .default,
                 sources: ["FirestoreService/Sources/**"],
                 dependencies: firestoreServiceDependencies
+            ),
+            Target(
+                name: "Than",
+                platform: .iOS,
+                product: .framework,
+                bundleId: "com.tnzkm.\(projectName).Than",
+                infoPlist: .default,
+                sources: ["Than/Sources/**"],
+                dependencies: []
             )
         ]
     }

--- a/Than/Sources/Than.swift
+++ b/Than/Sources/Than.swift
@@ -1,0 +1,49 @@
+//
+//  Than.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/11/19.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import UIKit
+
+public protocol Than {}
+
+extension Than where Self: Any {
+    
+    /// Value Type의 인스턴스를 생성한 후 `apply`을 통해 여러 설정을 진행합니다.
+    /// - Parameter apply: 설정을 진행할 클로저입니다.
+    /// - Returns: `apply`의 설정이 반영된 인스턴스를 반환합니다.
+    public func configure(_ apply: (inout Self) throws -> Void) rethrows -> Self {
+        var mutableSelf = self
+        
+        try apply(&mutableSelf)
+        return mutableSelf
+    }
+}
+
+extension Than where Self: AnyObject {
+    
+    /// 인스턴스를 생성한 후 `apply`를 통해 설정을 진행합니다.
+    /// - Parameter apply: 설정을 진행할 클로저입니다.
+    /// - Returns: `apply`의 설정이 반영된 인스턴스를 반환합니다.
+    public func than(_ apply: (Self) throws -> Void) rethrows -> Self {
+        try apply(self)
+        return self
+    }
+}
+
+extension NSObject: Than {}
+
+extension CGPoint:      Than {}
+extension CGRect:       Than {}
+extension CGSize:       Than {}
+
+extension Array:        Than {}
+extension Dictionary:   Than {}
+extension Set:          Than {}
+
+extension UIEdgeInsets: Than {}
+extension UIOffset:     Than {}
+extension UIRectEdge:   Than {}

--- a/Than/Sources/Than.swift
+++ b/Than/Sources/Than.swift
@@ -34,7 +34,7 @@ extension Than where Self: AnyObject {
     }
 }
 
-extension NSObject: Than {}
+extension NSObject:     Than {}
 
 extension CGPoint:      Than {}
 extension CGRect:       Than {}


### PR DESCRIPTION
# 작업 내용

resolved: 

# 질문 및 특이사항
```swift
extension NSObject:     Than {}

extension CGPoint:      Than {}
extension CGRect:       Than {}
extension CGSize:       Than {}

extension Array:        Than {}
extension Dictionary:   Than {}
extension Set:          Than {}

extension UIEdgeInsets: Than {}
extension UIOffset:     Than {}
extension UIRectEdge:   Than {}
```
위 타입들에 `than`을 적용할 수 있습니다.

- Value Type일 땐 configure (`let rect = CGRect().configure { ... }`)
- Class Type일 땐 than (`let view = UIView().than { ... }`)

으로 사용할 수 있습니다.

# 체크리스트
- [x] 빌드가 되는 코드인가요?
- [x] Warning이 없는 코드인가요?
- [x] Merge할 브랜치가 올바른가요?
- [x] 코딩 컨벤션이 올바른가요?
