### PR TITLE
Feature/refactor AuthReopository

### DIFF
--- a/Trinap/Sources/Data/Repositories/Auth/DefaultAuthRepository.swift
+++ b/Trinap/Sources/Data/Repositories/Auth/DefaultAuthRepository.swift
@@ -73,6 +73,8 @@ final class DefaultAuthRepository: AuthRepository {
         guard let userId = tokenManager.getToken(with: .userId) else {
             return .error(TokenManagerError.notFound)
         }
+        self.tokenManager.deleteToken(with: .userId)
+        self.tokenManager.deleteToken(with: .fcmToken)
         return firebaseStoreService.deleteDocument(
             collection: .users,
             document: userId
@@ -158,15 +160,11 @@ final class DefaultAuthRepository: AuthRepository {
         }
         
         return Single.create { [weak self] single in
-            guard let self else { return Disposables.create() }
-            
             user.delete { error in
                 if let error = error {
                     single(.failure(error))
                     return
                 }
-                self.tokenManager.deleteToken(with: .userId)
-                self.tokenManager.deleteToken(with: .fcmToken)
                 single(.success(()))
             }
             

--- a/Trinap/Sources/Data/Repositories/Auth/DefaultAuthRepository.swift
+++ b/Trinap/Sources/Data/Repositories/Auth/DefaultAuthRepository.swift
@@ -69,6 +69,52 @@ final class DefaultAuthRepository: AuthRepository {
         .asObservable()
     }
     
+    func removeUser() -> Observable<Void> {
+        guard let userId = tokenManager.getToken(with: .userId) else {
+            return .error(TokenManagerError.notFound)
+        }
+        return firebaseStoreService.deleteDocument(
+            collection: .users,
+            document: userId
+        )
+        .asObservable()
+    }
+    
+    func updateFcmToken() -> Observable<Void> {
+        guard
+            let userId = tokenManager.getToken(with: .userId),
+            let fcmToken = tokenManager.getToken(with: .fcmToken)
+        else {
+            return .error(TokenManagerError.notFound)
+        }
+        
+        let values = ["fcmToken": fcmToken]
+        
+        return firebaseStoreService.updateDocument(
+            collection: .users,
+            document: userId,
+            values: values
+        )
+        .asObservable()
+    }
+    
+    func deleteFcmToken() -> Observable<Void> {
+        guard
+            let userId = tokenManager.getToken(with: .userId)
+        else {
+            return .error(TokenManagerError.notFound)
+        }
+        
+        let values = ["fcmToken": ""]
+        
+        return firebaseStoreService.updateDocument(
+            collection: .users,
+            document: userId,
+            values: values
+        )
+        .asObservable()
+    }
+    
     func signIn(with cretencial: OAuthCredential) -> Single<String> {
         return Single.create { single in
                         
@@ -79,7 +125,6 @@ final class DefaultAuthRepository: AuthRepository {
                 }
                 
                 guard let userId = authResult?.user.uid else {
-                    // TODO: 인증 관련 에러를 구현하여 교체
                     single(.failure(LocalError.signInError))
                     return
                 }
@@ -91,10 +136,13 @@ final class DefaultAuthRepository: AuthRepository {
     }
     
     func signOut() -> Single<Void> {
-        return Single.create { single in
-
+        return Single.create { [weak self] single in
+            guard let self else { return Disposables.create() }
+            
             do {
                 try Auth.auth().signOut()
+                self.tokenManager.deleteToken(with: .userId)
+                self.tokenManager.deleteToken(with: .fcmToken)
                 single(.success(()))
             } catch let error {
                 single(.failure(error))
@@ -109,12 +157,16 @@ final class DefaultAuthRepository: AuthRepository {
             return .error(FireStoreError.unknown)
         }
         
-        return Single.create { single in
+        return Single.create { [weak self] single in
+            guard let self else { return Disposables.create() }
+            
             user.delete { error in
                 if let error = error {
                     single(.failure(error))
                     return
                 }
+                self.tokenManager.deleteToken(with: .userId)
+                self.tokenManager.deleteToken(with: .fcmToken)
                 single(.success(()))
             }
             

--- a/Trinap/Sources/Domain/Repositories/Auth/AuthRepository.swift
+++ b/Trinap/Sources/Domain/Repositories/Auth/AuthRepository.swift
@@ -17,6 +17,9 @@ protocol AuthRepository {
     // MARK: - Methods
     func checkUser() -> Single<Bool>
     func createUser(nickname: String) -> Observable<Void>
+    func removeUser() -> Observable<Void>
+    func updateFcmToken() -> Observable<Void>
+    func deleteFcmToken() -> Observable<Void>
     func signIn(with cretencial: OAuthCredential) -> Single<String>
     func signOut() -> Single<Void>
     func dropOut() -> Single<Void>

--- a/Trinap/Sources/Domain/UseCases/SignIn/DefaultSignInUseCase.swift
+++ b/Trinap/Sources/Domain/UseCases/SignIn/DefaultSignInUseCase.swift
@@ -42,4 +42,8 @@ final class DefaultSignInUseCase: SignInUseCase {
             return Observable.just(false)
         }
     }
+    
+    func updateFcmToken() -> Observable<Void> {
+        return authRepository.updateFcmToken()
+    }
 }

--- a/Trinap/Sources/Domain/UseCases/SignIn/SignInUseCase.swift
+++ b/Trinap/Sources/Domain/UseCases/SignIn/SignInUseCase.swift
@@ -16,4 +16,5 @@ protocol SignInUseCase {
     // MARK: - Methods
     func signIn(with credential: OAuthCredential) -> Observable<SignInResult>
     func autoSignIn() -> Observable<Bool>
+    func updateFcmToken() -> Observable<Void>
 }

--- a/Trinap/Sources/Presenter/Auth/SignIn/SignInViewModel.swift
+++ b/Trinap/Sources/Presenter/Auth/SignIn/SignInViewModel.swift
@@ -48,11 +48,16 @@ final class SignInViewModel: ViewModelType {
                 owner.signInUseCase.signIn(with: credentail)
             }
             .subscribe(onNext: { [weak self] reuslt in
+                guard let self else { return }
                 switch reuslt {
                 case.signUp:
-                    self?.coordinator?.showCreateUserViewController()
+                    self.coordinator?.showCreateUserViewController()
                 case .signIn:
-                    self?.coordinator?.finish()
+                    self.signInUseCase.updateFcmToken()
+                        .subscribe(onNext: {
+                            self.coordinator?.finish()
+                        })
+                        .disposed(by: self.disposeBag)
                 case .failure:
                     Logger.print("Sign 실패")
                 }


### PR DESCRIPTION
# 작업 내용
> 해결한 이슈 넘버와 설명을 적어주세요

- resolved: #165

# 질문 및 특이사항
> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요
- 새 기기에서 로그인 시 fcmToken이 업데이트 안되는 문제를 해결했습니다.
- AuthRepository에 `removeUser`, `updateFcmToken`, `deleteFcmToken` 함수를 추가혀였습니다.
- deleteFcmToken을 호출하면 User의 FcmToken 필드를 완전히 지우는게 아니라 빈 문자열이 들어가도록 구현했습니다.
- removeUser를 호출하면 User 정보 자체를 지우도록 구현했는데 어떻게 처리하는게 맞는지 상의해보면 좋을 것 같습니다.
- updateFcmToken를 호출하면 현재 KeyChain에 저장된 fcmToken으로 서버에 업데이트 합니다.
## 회원탈퇴 Flow
1. AuthRepository -> dropOut 호출: Firebase Auth에서 계정정보 삭제
2. AuthRepository -> removeUser 호출: FireStore에서 User Document 삭제
## 로그아웃 Flow
1. AuthRepository -> signOut 호출: Firebase Auth에서 로그아웃 처리
2. AuthRepository -> deleteFcmToken 호출: FireStore에서 User FcmToken을 빈 문자열로 변경

# 체크리스트
- [x] 빌드가 되는 코드인가요?
- [ ] Warning이 없는 코드인가요?
- [x] Merge할 브랜치가 올바른가요?
- [x] 코딩 컨벤션이 올바른가요?
