### PR TITLE
fix: itemSelected, itemDeselected 중복 코드 제거용 편의 메서드 구현

### DIFF
--- a/LocationCache/Sources/Cache/DiskLocationCache.swift
+++ b/LocationCache/Sources/Cache/DiskLocationCache.swift
@@ -1,0 +1,53 @@
+//
+//  DiskLocationCache.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+internal struct DiskLocationCache: LocationCacheProtocol {
+    
+    // MARK: - Properties
+    private let cacheQueue = DispatchQueue(label: "com.tnzkm.disk_location_cache", qos: .userInteractive)
+    private let fileManager = FileManager.default
+    
+    private var cacheURL: URL {
+        return fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+    }
+    
+    // MARK: - Methods
+    func reverseGeocodeLocation(_ location: CLLocation, preferredLocale: Locale?, completionHandler: @escaping (String, Error?) -> Void) {
+        cacheQueue.async {
+            let key = key(for: location)
+            let path = cacheURL.appendingPathExtension("\(key).coord")
+            if
+                let addressData = try? Data(contentsOf: path),
+                let address = String(data: addressData, encoding: .utf8)
+            {
+                completionHandler(address, nil)
+                return
+            }
+            
+            self.fetchLocation(location, preferredLocale: preferredLocale) { placemarks, error in
+                guard let address = placemarks?.first?.address else {
+                    completionHandler(error?.localizedDescription ?? "", LocationCacheError.noPlacemark)
+                    return
+                }
+                
+                try? address.write(to: path, atomically: true, encoding: .utf8)
+                
+                completionHandler(address, nil)
+            }
+        }
+    }
+    
+    private func fetchLocation(_ location: CLLocation, preferredLocale: Locale?, _ handler: @escaping CLGeocodeCompletionHandler) {
+        let geocoder = CLGeocoder()
+        
+        geocoder.reverseGeocodeLocation(location, preferredLocale: preferredLocale, completionHandler: handler)
+    }
+}

--- a/LocationCache/Sources/Cache/LocationCacheProtocol.swift
+++ b/LocationCache/Sources/Cache/LocationCacheProtocol.swift
@@ -1,0 +1,45 @@
+//
+//  LocationCacheProtocol.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import CoreLocation
+
+internal protocol LocationCacheProtocol {
+    
+    func reverseGeocodeLocation(_ location: CLLocation, preferredLocale: Locale?, completionHandler: @escaping (String, Error?) -> Void)
+    func key(for location: CLLocation) -> String
+}
+
+internal extension LocationCacheProtocol {
+    
+    func key(for location: CLLocation) -> String {
+        let latitude = "\(location.coordinate.latitude)".replacingOccurrences(of: ".", with: "_")
+        let longitude = "\(location.coordinate.longitude)".replacingOccurrences(of: ".", with: "_")
+        
+        return "\(latitude)__\(longitude).coord"
+    }
+}
+
+// MARK: - Cache Instance
+internal struct LocationCache {
+    
+    // MARK: - Properties
+    private let memoryLocationCache = MemoryLocationCache()
+    
+    // MARK: - Singleton
+    static let shared = LocationCache()
+    private init() {}
+    
+    // MARK: - Methods
+    func reverseGeocodeLocation(_ location: CLLocation, preferredLocale: Locale?, completionHandler: @escaping (String, Error?) -> Void) {
+        memoryLocationCache.reverseGeocodeLocation(
+            location,
+            preferredLocale: preferredLocale,
+            completionHandler: completionHandler
+        )
+    }
+}

--- a/LocationCache/Sources/Cache/MemoryLocationCache.swift
+++ b/LocationCache/Sources/Cache/MemoryLocationCache.swift
@@ -1,0 +1,38 @@
+//
+//  MemoryLocationCache.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+struct MemoryLocationCache: LocationCacheProtocol {
+    
+    // MARK: - Properties
+    private let cache = NSCache<NSString, NSString>()
+    private let diskLocationCache = DiskLocationCache()
+    
+    // MARK: - Methods
+    func reverseGeocodeLocation(_ location: CLLocation, preferredLocale: Locale?, completionHandler: @escaping (String, Error?) -> Void) {
+        let key = key(for: location) as NSString
+        
+        if let address = cache.object(forKey: key) {
+            completionHandler(address as String, nil)
+            return
+        }
+        
+        diskLocationCache.reverseGeocodeLocation(location, preferredLocale: preferredLocale) { address, error in
+            if let error {
+                completionHandler(address, error)
+                return
+            }
+            
+            cache.setObject(address as NSString, forKey: key)
+            
+            completionHandler(address, error)
+        }
+    }
+}

--- a/LocationCache/Sources/Extension/CLPlacemark+Address.swift
+++ b/LocationCache/Sources/Extension/CLPlacemark+Address.swift
@@ -1,0 +1,30 @@
+//
+//  CLPlacemark+Address.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import CoreLocation
+
+extension CLPlacemark {
+    
+    var address: String {
+        return fullLocationAddress
+    }
+    
+    var fullLocationAddress: String {
+        var placemarkData: [String] = []
+        
+        if let stateArea = subAdministrativeArea?.localizedCapitalized { placemarkData.append(stateArea) }
+        if let state = administrativeArea?.localizedCapitalized { placemarkData.append(state) }
+        if let city = locality?.localizedCapitalized { placemarkData.append(city) }
+        if let subCity = subLocality?.localizedCapitalized { placemarkData.append(subCity) }
+        if let street = thoroughfare?.localizedCapitalized { placemarkData.append(street) }
+        
+        placemarkData.removeDuplicates()
+        return placemarkData.joined(separator: " ")
+    }
+}
+

--- a/LocationCache/Sources/General/CLGeocoder+Cache.swift
+++ b/LocationCache/Sources/General/CLGeocoder+Cache.swift
@@ -1,0 +1,20 @@
+//
+//  CLGeocoder+Cache.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import CoreLocation
+
+extension LocationCacheWrapper where Base: CLGeocoder {
+    
+    public func reverseGeocodeLocation(_ location: CLLocation, preferredLocale: Locale? = nil, completionHandler: @escaping (String, Error?) -> Void) {
+        LocationCache.shared.reverseGeocodeLocation(
+            location,
+            preferredLocale: preferredLocale,
+            completionHandler: completionHandler
+        )
+    }
+}

--- a/LocationCache/Sources/General/LocationCacheError.swift
+++ b/LocationCache/Sources/General/LocationCacheError.swift
@@ -1,0 +1,21 @@
+//
+//  LocationCacheError.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import Foundation
+
+public enum LocationCacheError: LocalizedError {
+    
+    case noPlacemark
+    
+    public var errorDescription: String? {
+        switch self {
+        case .noPlacemark:
+            return "위치 정보를 확인할 수 없습니다."
+        }
+    }
+}

--- a/LocationCache/Sources/General/LocationCacheWrapper.swift
+++ b/LocationCache/Sources/General/LocationCacheWrapper.swift
@@ -1,0 +1,31 @@
+//
+//  LocationCacheWrapper.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import CoreLocation
+
+public struct LocationCacheWrapper<Base> {
+    
+    // MARK: - Properties
+    public let base: Base
+    
+    // MARK: - Methods
+    public init(base: Base) {
+        self.base = base
+    }
+}
+
+public protocol LocationCacheCompatible: AnyObject {}
+
+public extension LocationCacheCompatible {
+    
+    var useCache: LocationCacheWrapper<Self> {
+        return LocationCacheWrapper(base: self)
+    }
+}
+
+extension CLGeocoder: LocationCacheCompatible {}

--- a/Project.swift
+++ b/Project.swift
@@ -42,6 +42,7 @@ class BaseProjectFactory: ProjectFactory {
         .target(name: "Queenfisher"),
         .target(name: "FirestoreService"),
         .target(name: "Than"),
+        .target(name: "LocationCache"),
     ]
     
     let testDependencies: [TargetDependency] = [
@@ -152,6 +153,15 @@ class BaseProjectFactory: ProjectFactory {
                 bundleId: "com.tnzkm.\(projectName).Than",
                 infoPlist: .default,
                 sources: ["Than/Sources/**"],
+                dependencies: []
+            ),
+            Target(
+                name: "LocationCache",
+                platform: .iOS,
+                product: .framework,
+                bundleId: "com.tnzkm.\(projectName).LocationCache",
+                infoPlist: .default,
+                sources: ["LocationCache/Sources/**"],
                 dependencies: []
             )
         ]

--- a/Trinap/Sources/Presenter/Common/Extension/RxSwift+CollectionViewDataSource.swift
+++ b/Trinap/Sources/Presenter/Common/Extension/RxSwift+CollectionViewDataSource.swift
@@ -1,0 +1,47 @@
+//
+//  RxSwift+CollectionViewDataSource.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: UICollectionView {
+    
+    public func itemSelected<Section, Item>(
+        at dataSource: UICollectionViewDiffableDataSource<Section, Item>?
+    ) -> Observable<Item> {
+        return delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didSelectItemAt:)))
+            .map { object in
+                return try castOrThrow(IndexPath.self, object[1])
+            }
+            .compactMap { indexPath in
+                return dataSource?.itemIdentifier(for: indexPath)
+            }
+    }
+    
+    public func itemDeselected<Section, Item>(
+        at dataSource: UICollectionViewDiffableDataSource<Section, Item>?
+    ) -> Observable<Item> {
+        return delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didDeselectItemAt:)))
+            .compactMap { object in
+                return try castOrThrow(IndexPath.self, object[1])
+            }
+            .compactMap { indexPath in
+                return dataSource?.itemIdentifier(for: indexPath)
+            }
+    }
+    
+    private func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
+        guard let returnValue = object as? T else {
+            throw RxCocoaError.castingError(object: object, targetType: resultType)
+        }
+        
+        return returnValue
+    }
+}

--- a/Trinap/Sources/Presenter/Common/Extension/RxSwift+TableViewDataSource.swift
+++ b/Trinap/Sources/Presenter/Common/Extension/RxSwift+TableViewDataSource.swift
@@ -1,0 +1,47 @@
+//
+//  RxSwift+TableViewDataSource.swift
+//  Trinap
+//
+//  Created by 김세영 on 2022/12/27.
+//  Copyright © 2022 Trinap. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: UITableView {
+    
+    public func itemSelected<Section, Item>(
+        at dataSource: UITableViewDiffableDataSource<Section, Item>?
+    ) -> Observable<Item> {
+        return delegate.methodInvoked(#selector(UITableViewDelegate.tableView(_:didSelectRowAt:)))
+            .map { object in
+                return try castOrThrow(IndexPath.self, object[1])
+            }
+            .compactMap { indexPath in
+                return dataSource?.itemIdentifier(for: indexPath)
+            }
+    }
+    
+    public func itemDeselected<Section, Item>(
+        at dataSource: UITableViewDiffableDataSource<Section, Item>?
+    ) -> Observable<Item> {
+        return delegate.methodInvoked(#selector(UITableViewDelegate.tableView(_:didDeselectRowAt:)))
+            .compactMap { object in
+                return try castOrThrow(IndexPath.self, object[1])
+            }
+            .compactMap { indexPath in
+                return dataSource?.itemIdentifier(for: indexPath)
+            }
+    }
+    
+    private func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
+        guard let returnValue = object as? T else {
+            throw RxCocoaError.castingError(object: object, targetType: resultType)
+        }
+        
+        return returnValue
+    }
+}

--- a/Trinap/Sources/Presenter/TabBar/Main/PhotographerList/PhotographerListViewController.swift
+++ b/Trinap/Sources/Presenter/TabBar/Main/PhotographerList/PhotographerListViewController.swift
@@ -28,9 +28,12 @@ final class PhotographerListViewController: BaseViewController {
         $0.estimatedItemSize = CGSize(width: width, height: height)
         $0.scrollDirection = .vertical
     }
+    
+    private lazy var refreshControl = UIRefreshControl()
         
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout).than {
         $0.register(PhotographerPreviewCell.self)
+        $0.refreshControl = refreshControl
         $0.backgroundColor = TrinapAsset.white.color
     }
     
@@ -51,9 +54,6 @@ final class PhotographerListViewController: BaseViewController {
         super.viewWillAppear(animated)
         
         configureNavigationBar()
-        
-        collectionView.isSkeletonable = true
-        collectionView.showSkeleton()
     }
     
     override func configureHierarchy() {
@@ -80,6 +80,9 @@ final class PhotographerListViewController: BaseViewController {
 
     override func configureAttributes() {
         dataSource = configureDataSource()
+        
+        collectionView.isSkeletonable = true
+        collectionView.showSkeleton()
     }
 
     override func bind() {
@@ -102,10 +105,10 @@ final class PhotographerListViewController: BaseViewController {
             .when(.recognized)
             .asObservable()
             .map { _ in }
-                
+        
         let input = PhotographerListViewModel.Input(
-            viewWillAppear: self.rx.viewWillAppear.asObservable(),
             searchTrigger: searchTrigger,
+            refresh: refreshControl.rx.controlEvent(.valueChanged).asObservable(),
             tagType: type
         )
         
@@ -116,6 +119,7 @@ final class PhotographerListViewController: BaseViewController {
                 self?.generateSnapshot(sources: previews)
             }
             .drive(onNext: { [weak self] snapshot in
+                self?.refreshControl.endRefreshing()
                 self?.collectionView.hideSkeleton()
                 self?.dataSource?.apply(snapshot, animatingDifferences: false)
             })

--- a/Trinap/Sources/Presenter/TabBar/Main/PhotographerList/PhotographerListViewController.swift
+++ b/Trinap/Sources/Presenter/TabBar/Main/PhotographerList/PhotographerListViewController.swift
@@ -121,10 +121,7 @@ final class PhotographerListViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
         
-        collectionView.rx.itemSelected
-            .compactMap { [weak self] indexPath in
-                return self?.dataSource?.itemIdentifier(for: indexPath)
-            }
+        collectionView.rx.itemSelected(at: dataSource)
             .bind(onNext: { [weak self] preview in
                 self?.viewModel.showDetailPhotographer(userId: preview.photographerUserId)
             })

--- a/Trinap/Sources/Presenter/TabBar/MyPage/Contact/ContactListViewController.swift
+++ b/Trinap/Sources/Presenter/TabBar/MyPage/Contact/ContactListViewController.swift
@@ -74,9 +74,7 @@ final class ContactListViewController: BaseViewController {
     override func bind() {
         let input = ContactListViewModel.Input(
             viewWillAppear: self.rx.viewWillAppear.map { _ in }.asObservable(),
-            cellDidSelect: tableView.rx.itemSelected
-                .compactMap { self.dataSource?.itemIdentifier(for: $0)?.contactId }
-                .asObservable(),
+            cellDidSelect: tableView.rx.itemSelected(at: dataSource).map(\.contactId),
             addContactTap: self.addButton.rx.tap.asSignal(),
             backButtonTap: self.navigationBarView.backButton.rx.tap.asSignal()
         )

--- a/Trinap/Sources/Presenter/TabBar/MyPage/Photographer/Register/RegisterPhotographerInfoViewController.swift
+++ b/Trinap/Sources/Presenter/TabBar/MyPage/Photographer/Register/RegisterPhotographerInfoViewController.swift
@@ -310,22 +310,16 @@ extension RegisterPhotographerInfoViewController {
     }
     
     private func collectionViewBinding() {        
-        tagCollectionView.rx.itemSelected
-            .withUnretained(self)
-            .compactMap { owner, indexPath in
-                return owner.dataSource?.itemIdentifier(for: indexPath)?.tag
-            }
+        tagCollectionView.rx.itemSelected(at: dataSource)
+            .map(\.tag)
             .withUnretained(self)
             .subscribe(onNext: { owner, tag in
                 owner.selectedTags.accept(owner.selectedTags.value + [tag])
             })
             .disposed(by: disposeBag)
 
-        tagCollectionView.rx.itemDeselected
-            .withUnretained(self)
-            .compactMap { owner, indexPath in
-                return owner.dataSource?.itemIdentifier(for: indexPath)?.tag
-            }
+        tagCollectionView.rx.itemDeselected(at: dataSource)
+            .map(\.tag)
             .withUnretained(self)
             .subscribe(onNext: { owner, tag in
                 let removedValue = owner.selectedTags.value.filter { $0 != tag }

--- a/Trinap/Sources/Presenter/TabBar/Reservation/ReservationList/ReservationPreviewListViewController.swift
+++ b/Trinap/Sources/Presenter/TabBar/Reservation/ReservationList/ReservationPreviewListViewController.swift
@@ -102,19 +102,15 @@ final class ReservationPreviewListViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
         
-        reservationListTableView.rx.itemSelected
-            .bind(onNext: { [weak self] indexPath in
-                self?.showReservationDetailViewController(at: indexPath)
+        reservationListTableView.rx.itemSelected(at: dataSource)
+            .bind(onNext: { [weak self] preview in
+                self?.showReservationDetailViewController(preview)
             })
             .disposed(by: disposeBag)
-        
-        
     }
     
-    private func showReservationDetailViewController(at indexPath: IndexPath) {
-        guard let reservationPreview = self.dataSource?.itemIdentifier(for: indexPath) else { return }
-        
-        viewModel.presentReservationDetail(reservationId: reservationPreview.reservationId)
+    private func showReservationDetailViewController(_ preview: Reservation.Preview) {
+        viewModel.presentReservationDetail(reservationId: preview.reservationId)
     }
 }
 

--- a/Trinap/Sources/Presenter/TabBar/Search/SearchViewController.swift
+++ b/Trinap/Sources/Presenter/TabBar/Search/SearchViewController.swift
@@ -89,12 +89,7 @@ final class SearchViewController: BaseViewController {
             .bind(to: searchBar.textField.rx.text)
             .disposed(by: disposeBag)
         
-        let selectedSpace = searchTableView.rx.itemSelected
-            .asObservable()
-            .map { [weak self] index -> Space? in
-                self?.dataSource?.itemIdentifier(for: index)
-            }
-            .compactMap { $0 }
+        let selectedSpace = searchTableView.rx.itemSelected(at: dataSource)
 
         selectedSpace
             .map { $0.name }


### PR DESCRIPTION
# 작업 내용
tableView와 collectionView의 ItemSelected, Deselected 시 중복된 코드가 발생하는 문제를 해결하였습니다.

# 질문 및 특이사항
```swift
var dataSource: UITableViewDiffableDataSource<Section, Item>?
// ...
// or collectionView
tableView.rx.itemSelected(at: dataSource)
    .bind(onNext: { ... })
    .disposed(by: disposeBag)
```

`itemSelected(at:)`과 `itemDeselected(at:)`의 반환값은 `Observable<Item>` 타입이므로 Item을 바로 사용할 수 잇읍니다.

# 체크리스트
- [ ] 빌드가 되는 코드인가요?
- [ ] Warning이 없는 코드인가요?
- [ ] Merge할 브랜치가 올바른가요?
- [ ] 코딩 컨벤션이 올바른가요?
